### PR TITLE
Fix handling of alpha versions

### DIFF
--- a/standard/ci-teamcity/Set-SemanticTagFromBranchName.ps1
+++ b/standard/ci-teamcity/Set-SemanticTagFromBranchName.ps1
@@ -36,7 +36,7 @@ function Get-SemanticTag($lowercaseBranch, $commitId, $masterTag)
     if ($lowercaseBranch.StartsWith("candidate/")) { return "rc"; }
     if ($lowercaseBranch.StartsWith("release/")) { return "release"; }
     if ($lowercaseBranch.Equals("master")) { return "${masterTag}"; }
-    return "alpha.${commitId}";
+    return "alpha.g${commitId}";
 }
 
 $commitId = Get-CommitId;

--- a/standard/ci-teamcity/Set-VersionFromGit.ps1
+++ b/standard/ci-teamcity/Set-VersionFromGit.ps1
@@ -49,6 +49,9 @@ if (-not $majorMinor) { Die 0 "The .current-version file is empty. No attempt wi
 $majorMinor = $majorMinor.Trim();
 if (-not $majorMinor) { Die 0 "The .current-version file is empty. No attempt will be made to infer version number."; }
 
+# Ensure that the version base tag is actually known to the local repository:
+Invoke-Git fetch origin tag "${majorMinor}"
+
 if (-not (Test-Tag "${majorMinor}")) { Die 2 "Could not find a tag with the name '${majorMinor}'." }
 
 $buildNumber = $(Count-Revisions $majorMinor);

--- a/standard/ci-teamcity/StandardVersionedBuild.xml
+++ b/standard/ci-teamcity/StandardVersionedBuild.xml
@@ -65,6 +65,9 @@ if (-not $majorMinor) { Die 0 "The .current-version file is empty. No attempt wi
 $majorMinor = $majorMinor.Trim();
 if (-not $majorMinor) { Die 0 "The .current-version file is empty. No attempt will be made to infer version number."; }
 
+# Ensure that the version base tag is actually known to the local repository:
+Invoke-Git fetch origin tag "${majorMinor}"
+
 if (-not (Test-Tag "${majorMinor}")) { Die 2 "Could not find a tag with the name '${majorMinor}'." }
 
 $buildNumber = $(Count-Revisions $majorMinor);

--- a/standard/ci-teamcity/StandardVersionedBuild.xml
+++ b/standard/ci-teamcity/StandardVersionedBuild.xml
@@ -135,7 +135,7 @@ function Get-SemanticTag($lowercaseBranch, $commitId, $masterTag)
     if ($lowercaseBranch.StartsWith("candidate/")) { return "rc"; }
     if ($lowercaseBranch.StartsWith("release/")) { return "release"; }
     if ($lowercaseBranch.Equals("master")) { return "${masterTag}"; }
-    return "alpha.${commitId}";
+    return "alpha.g${commitId}";
 }
 
 $commitId = Get-CommitId;


### PR DESCRIPTION
* Fetch version base tag before doing topology analysis, in case TeamCity didn't fetch that ref.
* Prepend 'g' to commit hash component of alpha tag, to avoid leading zeroes.

refs INF-326, INF-547