### PR TITLE
Add Xamarin-related improvements

### DIFF
--- a/standard/repository-v2/Build.props
+++ b/standard/repository-v2/Build.props
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    <ItemGroup>
+        <!-- Full list of NuGet package projects -->
+        <NugetProjects Include="**\*.Contracts.csproj" />
+
+        <!-- Full list of NUnit test projects -->
+        <NUnitProjects Include="**\*.UnitTests.csproj" />
+    </ItemGroup>
+    <PropertyGroup>
+        <DotCoverConfigurationFile>DotCover.coverage.xml</DotCoverConfigurationFile>
+    </PropertyGroup>
+</Project>

--- a/standard/repository-v2/Common.props
+++ b/standard/repository-v2/Common.props
@@ -4,8 +4,6 @@
   <PropertyGroup>
     <Configuration>Release</Configuration>
     <PreferredMSBuildToolsVersion>15.0</PreferredMSBuildToolsVersion>
-    <PowerShellExe Condition="'$(PowerShellExe)' == ''">%WINDIR%\System32\WindowsPowerShell\v1.0\powershell.exe</PowerShellExe>
-    <PowerShellInvocation>&quot;$(PowerShellExe)&quot; -Version 2.0 -NonInteractive -ExecutionPolicy Unrestricted</PowerShellInvocation>
   </PropertyGroup>
 
 </Project>

--- a/standard/repository-v2/Common.targets
+++ b/standard/repository-v2/Common.targets
@@ -1,0 +1,155 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <Target Name="PrepareNUnitRunner">
+    <!--
+        Look for the NUnit tools directory.
+        LastMatch is used so that we get the highest version of runner available.
+    -->
+    <ItemGroup>
+        <NUnitPaths Include="packages\Nunit*\tools\nunit3-console.exe" />
+        <NUnitPaths Include="packages\Nunit*\*\tools\nunit3-console.exe" />
+    </ItemGroup>
+    <FindInList List="@(NUnitPaths)" FindLastMatch="true" ItemSpecToFind="%(NUnitPaths.Identity)" >
+        <Output TaskParameter="ItemFound" PropertyName="NUnitRunnerPath"/>
+    </FindInList>
+    <Message Text="NUnit runner paths: @(NUnitPaths)" />
+    <Error Condition="'$(NUnitRunnerPath)' == ''" Text="Could not find NUnit runner executable." />
+    <Error Condition="!Exists('$(NUnitRunnerPath)')" Text="Could not find NUnit runner executable." />
+
+    <Message Text="Using NUnit at: $(NUnitRunnerPath)" />
+
+    <PropertyGroup>
+      <NumberOfParallelAgents>$(NUMBER_OF_PROCESSORS)</NumberOfParallelAgents>
+      <NumberOfParallelAgents Condition="'$(NumberOfParallelAgents)' == ''">4</NumberOfParallelAgents>
+    </PropertyGroup>
+    <Message Text="Limit NUnit agent concurrency to $(NumberOfParallelAgents)" />
+  </Target>
+
+  <Target Name="PrepareDotCover" Condition="'$(DotCoverConfigurationFile)' != ''">
+    <!--
+        Look for the dotCover command line runner.
+        LastMatch is used so that we get the highest version of runner available.
+    -->
+    <ItemGroup>
+        <DotCoverPaths Condition="'$(agent_home_dir)' != ''" Include="$(agent_home_dir)\tools\**\dotCover.exe" />
+        <DotCoverPaths Include="$(LOCALAPPDATA)\JetBrains\Installations\**\dotCover.exe" />
+        <DotCoverPaths Include="packages\JetBrains.dotCover.CommandLineTools*\tools\dotCover.exe" />
+        <DotCoverPaths Include="packages\JetBrains.dotCover.CommandLineTools\*\tools\dotCover.exe" />
+    </ItemGroup>
+    <ItemGroup>
+        <DotCoverDirectories Include="@(DotCoverPaths->'%(RootDir)%(Directory)')" />
+    </ItemGroup>
+    <FindInList List="@(DotCoverDirectories)" FindLastMatch="true" ItemSpecToFind="%(DotCoverDirectories.Identity)" >
+        <Output TaskParameter="ItemFound" PropertyName="DotCoverRunnerDirectory"/>
+    </FindInList>
+    <Message Text="dotCover runner paths: @(DotCoverPaths)" />
+    <Error Condition="'$(DotCoverRunnerDirectory)' == ''" Text="Could not find dotCover runner executable." />
+    <PropertyGroup>
+        <DotCoverRunnerPath>$(DotCoverRunnerDirectory)dotCover.exe</DotCoverRunnerPath>
+    </PropertyGroup>
+    <Error Condition="!Exists('$(DotCoverRunnerPath)')" Text="Could not find dotCover runner executable." />
+
+    <Message Text="##teamcity[dotNetCoverage dotcover_home='$(DotCoverRunnerDirectory)']" />
+    <Message Text="Using dotCover at: $(DotCoverRunnerPath)" />
+  </Target>
+
+  <Target Name="BuildNUnitTestAssemblies" Condition="'@(NUnitProjects)' != ''">
+    <MSBuild Projects="@(NUnitProjects)" Targets="DispatchToInnerBuilds" ToolsVersion="$(PreferredMSBuildToolsVersion)" BuildInParallel="true" Properties="@(_BuildProperties);InnerTargets=Build" >
+        <Output TaskParameter="TargetOutputs" ItemName="NUnitProjectAssemblies" />
+    </MSBuild>
+    <Error Condition="'@(NUnitProjectAssemblies)' == ''" Text="NUnit projects were found, but the build produced no assemblies." />
+
+    <ConvertToAbsolutePath Paths="@(NUnitProjects)">
+        <Output TaskParameter="AbsolutePaths" ItemName="NUnitProjectsAbsolute" />
+    </ConvertToAbsolutePath>
+    <ItemGroup>
+        <NUnitProjectsOutputs Include="%(NUnitProjectAssemblies.MSBuildSourceProjectFile)">
+            <TargetPath>%(NUnitProjectAssemblies.Identity)</TargetPath>
+        </NUnitProjectsOutputs>
+        <NUnitTestProjects Include="%(Identity)">
+            <DependsOn>@(NUnitProjectsAbsolute->'%(DependsOn)')</DependsOn>
+            <TargetPath>@(NUnitProjectsOutputs->'%(TargetPath)')</TargetPath>
+            <DotCoverSnapshot>@(NUnitProjectsOutputs->'%(TargetPath).dcvr')</DotCoverSnapshot>
+        </NUnitTestProjects>
+    </ItemGroup>
+  </Target>
+
+  <Target Name="_SelectCoverageTool" DependsOnTargets="PrepareDotCover">
+    <PropertyGroup>
+      <CoverageToolName Condition="'$(DotCoverRunnerPath)' != ''">DotCover</CoverageToolName>
+      <CoverageToolName Condition="'$(CoverageToolName)' == ''">*NONE*</CoverageToolName>
+    </PropertyGroup>
+    <Message Text="Coverage tool: $(CoverageToolName)" />
+  </Target>
+
+  <Target Name="RunNUnitTests" Condition="'@(NUnitProjects)' != ''" DependsOnTargets="_SelectCoverageTool;RunNUnitTestsOnly;RunNUnitTestsWithDotCover">
+  </Target>
+
+  <Target Name="RunNUnitTestsOnly" Condition="'$(CoverageToolName)' == '*NONE*'" DependsOnTargets="_RunNUnitTestsOnly">
+  </Target>
+
+  <Target Name="_RunNUnitTestsOnly" Inputs="@(NUnitTestProjects)" Outputs="%(Identity).skip" DependsOnTargets="PrepareNUnitRunner;BuildNUnitTestAssemblies">
+    <Message Text="%(NUnitTestProjects.Identity):" />
+    <Message Text="     %(NUnitTestProjects.TargetPath)" />
+    <Message Text="     %(NUnitTestProjects.DependsOn)" />
+
+    <MSBuild Projects="%(NUnitTestProjects.Identity)" Condition="'%(NUnitTestProjects.DependsOn)'!=''" Targets="%(NUnitTestProjects.DependsOn)" />
+
+    <Exec Command='"$(NUnitRunnerPath)" --teamcity --agents=$(NumberOfParallelAgents) "%(NUnitTestProjects.TargetPath)"' />
+  </Target>
+
+  <Target Name="RunNUnitTestsWithDotCover" Condition="'$(CoverageToolName)' == 'DotCover'" DependsOnTargets="_RunNUnitTestsWithDotCover">
+    <PropertyGroup>
+      <DotCoverMergedSnapshotPath>_DotCoverMergedSnapshot.dcvr</DotCoverMergedSnapshotPath>
+    </PropertyGroup>
+    <Exec Command='"$(DotCoverRunnerPath)" merge /Source="@(DotCoverSnapshots)" /Output="$(DotCoverMergedSnapshotPath)"' />
+
+    <Exec Condition="'$(DotCoverXmlReportPath)' != ''" Command='"$(DotCoverRunnerPath)" report /Source="$(DotCoverMergedSnapshotPath)" /Output="$(DotCoverXmlReportPath)" /ReportType=XML' />
+    <Exec Condition="'$(DotCoverHtmlReportPath)' != ''" Command='"$(DotCoverRunnerPath)" report /Source="$(DotCoverMergedSnapshotPath)" /Output="$(DotCoverHtmlReportPath)" /ReportType=HTML' />
+
+  </Target>
+
+  <Target Name="_RunNUnitTestsWithDotCover" Inputs="@(NUnitTestProjects)" Outputs="%(Identity).skip" DependsOnTargets="PrepareNUnitRunner;PrepareDotCover;BuildNUnitTestAssemblies">
+    <Message Text="%(NUnitTestProjects.Identity):" />
+    <Message Text="     %(NUnitTestProjects.TargetPath)" />
+    <Message Text="     %(NUnitTestProjects.DependsOn)" />
+    <Message Text="     %(NUnitTestProjects.DotCoverSnapshot)" />
+
+    <ItemGroup>
+      <_DotCoverCoverageArguments Include='cover' />
+      <_DotCoverCoverageArguments Include='"$(DotCoverConfigurationFile)"' />
+      <_DotCoverCoverageArguments Include='/Output="%(NUnitTestProjects.DotCoverSnapshot)"' />
+      <_DotCoverCoverageArguments Include='/TargetExecutable="$(NUnitRunnerPath)"' />
+      <_DotCoverCoverageArguments Include='/TargetArguments="--teamcity --agents=$(NumberOfParallelAgents) \"%(NUnitTestProjects.TargetPath)\""' />
+    </ItemGroup>
+    <MSBuild Projects="%(NUnitTestProjects.Identity)" Condition="'%(NUnitTestProjects.DependsOn)'!=''" Targets="%(NUnitTestProjects.DependsOn)" />
+
+    <Exec Command="&quot;$(DotCoverRunnerPath)&quot; @(_DotCoverCoverageArguments, ' ')" />
+    <Message Text="##teamcity[importData type='dotNetCoverage' tool='dotcover' path='%(NUnitTestProjects.DotCoverSnapshot)']" />
+
+    <ItemGroup>
+      <DotCoverSnapshots Include="%(NUnitTestProjects.DotCoverSnapshot)" />
+    </ItemGroup>
+  </Target>
+
+  <Target Name="PrepareBuildProperties">
+    <ItemGroup>
+      <_BuildProperties Include="RestorePackagesPath=$(MSBuildProjectDirectory)\packages" />
+      <_BuildProperties Include="VersionSuffix=$(SemanticTag)" />
+      <_BuildProperties Include="PackageOutputPath=$(OutputDirectory)" />
+    </ItemGroup>
+    
+    <ItemGroup>
+      <NugetProjects UndefineProperties="Version" />
+      <NugetProjects Condition="'%(NugetProjects.UseSemVer)' != 'true'" AdditionalProperties="VersionPrefix=$(Version)" />
+      
+      <OctoPackProjects UndefineProperties="Version" />
+      <OctoPackProjects Condition="'%(OctoPackProjects.UseSemVer)' != 'true'" AdditionalProperties="VersionPrefix=$(Version)" />
+      
+      <OutputBinaryProjects UndefineProperties="Version" />
+      <OutputBinaryProjects Condition="'%(OutputBinaryProjects.UseSemVer)' != 'true'" AdditionalProperties="VersionPrefix=$(Version)" />
+    </ItemGroup>
+  </Target>
+
+</Project>

--- a/standard/repository-v2/DotCover.coverage.xml
+++ b/standard/repository-v2/DotCover.coverage.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<CoverageParams>
+  <Filters>
+    <IncludeFilters>
+      <!-- Modern naming convention: all project names should start with 'Bluewire.' -->
+      <FilterEntry><ModuleMask>Bluewire.*</ModuleMask></FilterEntry>
+    </IncludeFilters>
+    <ExcludeFilters>
+      <!-- Default exclusions -->
+      <FilterEntry><ModuleMask>*Tests</ModuleMask></FilterEntry>
+      <FilterEntry><ModuleMask>*.Contracts</ModuleMask></FilterEntry>
+      <FilterEntry><ModuleMask>*.Contracts.*</ModuleMask></FilterEntry>
+    </ExcludeFilters>
+  </Filters>
+</CoverageParams>

--- a/standard/repository-v2/NuGet.Config
+++ b/standard/repository-v2/NuGet.Config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <add key="Committed" value="nuget-local" />
+  </packageSources>
+</configuration>

--- a/standard/repository-v2/TeamCity.Task.proj
+++ b/standard/repository-v2/TeamCity.Task.proj
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="BuildAndTest" ToolsVersion="12.0">
+
+    <!--
+
+    Standard Build Script
+    Intended to isolate the codebase from the details of the CI server.
+
+    Inputs:
+      * OutputDirectory:  location for final build output
+      * Version:          (optional) version number to use for auto-versioned projects
+      * SemanticTag:      (optional) semantic tag to apply to auto- and SemVer-versioned projects (default: alpha)
+
+    Outputs:
+      * Everything in OutputDirectory
+
+    Do not customise this file. Add projects or override constants in Build.props.
+
+    -->
+
+    <Import Project="Common.props" />
+    <Import Project="Common.targets" />
+
+    <PropertyGroup>
+        <WorkingDirectory>$(MSBuildProjectDirectory)</WorkingDirectory>
+        <Version></Version>
+        <SemanticTag>alpha</SemanticTag>
+    </PropertyGroup>
+
+    <ItemDefinitionGroup>
+        <!-- Projects which produce NuGet packages. -->
+        <NugetProjects></NugetProjects>
+        <!-- NUnit test projects. -->
+        <NUnitProjects></NUnitProjects>
+        <!-- Projects which reference OctoPack and use it to produce Octopus packages. -->
+        <OctoPackProjects></OctoPackProjects>
+        <!-- Specific binary files which should be copied directly to the output directory. -->
+        <OutputBinaries></OutputBinaries>
+        <!-- Projects which produce files which should be copied directly to the output directory. -->
+        <OutputBinaryProjects></OutputBinaryProjects>
+    </ItemDefinitionGroup>
+
+    <!-- Do not add project references to this file. Add them in Build.props instead. -->
+
+    <Import Project="Build.props" />
+
+    <ItemGroup>
+        <_BuildProperties Include="Configuration=$(Configuration)" />
+    </ItemGroup>
+
+    <Target DependsOnTargets="ValidateParameters;PrepareOutputDirectory;PrepareBuildProperties;Restore" Name="Build">
+        <MSBuild Projects="@(NugetProjects)" Targets="Build" ToolsVersion="$(PreferredMSBuildToolsVersion)" BuildInParallel="true" Properties="@(_BuildProperties)" />
+        <MSBuild Projects="@(OutputBinaryProjects)" Targets="Build" ToolsVersion="$(PreferredMSBuildToolsVersion)" BuildInParallel="true" Properties="@(_BuildProperties)">
+            <Output TaskParameter="TargetOutputs" ItemName="_ProjectOutputBinaries" />
+        </MSBuild>
+        <ItemGroup>
+            <_ProjectOutputConfigurationFiles Include="@(_ProjectOutputBinaries->'%(Identity).config')" />
+            <OutputBinaries Include="@(_ProjectOutputBinaries)" />
+            <OutputBinaries Include="%(_ProjectOutputConfigurationFiles.Identity)" Condition="Exists('%(Identity)')" />
+        </ItemGroup>
+        <MSBuild Projects="@(OctoPackProjects)" Targets="Build" ToolsVersion="$(PreferredMSBuildToolsVersion)" BuildInParallel="true" Properties="@(_BuildProperties)" />
+    </Target>
+    
+    <Target Name="Restore">
+        <ItemGroup>
+            <_AllProjects Include="@(NugetProjects)" />
+            <_AllProjects Include="@(NUnitProjects)" />
+            <_AllProjects Include="@(OctoPackProjects)" />
+            <_AllProjects Include="@(OutputBinaryProjects)" />
+        </ItemGroup>
+        <MSBuild Projects="@(_AllProjects)" Targets="Restore" ToolsVersion="$(PreferredMSBuildToolsVersion)" BuildInParallel="true" Properties="@(_BuildProperties)" />
+    </Target>
+
+    <Target Name="BuildAndTest" DependsOnTargets="Build;RunNUnitTests">
+    </Target>
+   
+    <Target Name="BuildAndPackage" DependsOnTargets="BuildAndTest">
+        <MSBuild Projects="@(NugetProjects)" Targets="Build" ToolsVersion="$(PreferredMSBuildToolsVersion)" BuildInParallel="true" Properties="@(_BuildProperties)"/>
+        <Copy SourceFiles="@(OutputBinaries)" DestinationFiles="@(OutputBinaries->'$(OutputDirectory)\%(FileName)%(Extension)')" />
+        <MSBuild Projects="@(OctoPackProjects)" Targets="Build" ToolsVersion="$(PreferredMSBuildToolsVersion)" BuildInParallel="true" Properties="@(_BuildProperties);RunOctoPack=true;OctoPackPublishPackageToFileShare=$(OutputDirectory)" />
+    </Target>
+
+    <Target Name="PrepareOutputDirectory" DependsOnTargets="ValidateParameters">
+        <MakeDir Directories="$(OutputDirectory)" />
+    </Target>
+
+    <Target Name="ValidateParameters">
+        <Warning Text="Version was not specified" Condition="'$(Version)' == ''" />
+        <Error Text="OutputDirectory was not specified" Condition="'$(OutputDirectory)' == ''" />
+
+        <!-- Make paths absolute -->
+        <CombinePath BasePath="$(MSBuildProjectDirectory)" Paths="$(OutputDirectory)">
+            <Output TaskParameter="CombinedPaths" PropertyName="OutputDirectory" />
+        </CombinePath>
+
+        <Message Text="Source Version:   $(Version)" />
+        <Message Text="Semantic Tag:     $(SemanticTag)" />
+        <Message Text="Output Directory: $(OutputDirectory)" />
+    </Target>
+</Project>

--- a/standard/repository-v2/nuget-local/README.md
+++ b/standard/repository-v2/nuget-local/README.md
@@ -1,0 +1,3 @@
+= Committed Package Repository =
+
+Put private .nupkg dependencies here. They will automatically be unpacked to the packages/ folder during the build.

--- a/stylecop/StyleCopAnalyzers.props
+++ b/stylecop/StyleCopAnalyzers.props
@@ -3,6 +3,17 @@
   <PropertyGroup>
     <StyleCopAnalyzersRootPath>$(MSBuildThisFileDirectory)StyleCopAnalyzers\</StyleCopAnalyzersRootPath>
     <CodeAnalysisRuleSet>$(StyleCopAnalyzersRootPath)CodeAnalysisRules.ruleset</CodeAnalysisRuleSet>
+    
+    <!--
+        * Suppress XML comment warnings completely.
+        * Ignore duplicate 'using' statements, which might be introduced by merges.
+      -->
+    <NoWarn>1591,1592,1573,1574,1571,1570,1572,1711,1587,0105</NoWarn>
+    <!-- Treat warnings as errors by default: -->
+    <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
+    <!-- Keep '#warning' and some internally-suppressed warnings as warnings: -->
+    <WarningsNotAsErrors>1030,1701,1702</WarningsNotAsErrors>
+    
   </PropertyGroup>
 
   <!-- Enable stylecop analyzers for all non-release builds or a release build that's running a build in visual studio (i.e. Intellisense). -->


### PR DESCRIPTION
* Add style rules to Xamarin and .NET Standard projects.
* Force build failures for style violations.
* Use local packages cache directory for CI build compatibility.
* Add a 'committed' package repository for private dependencies.
* Invoke package restore before CI builds.
* Update default MSBuild tools version to 15.