### PR TITLE
Further build refinements

### DIFF
--- a/standard/repository-v2/Common.targets
+++ b/standard/repository-v2/Common.targets
@@ -135,9 +135,9 @@
 
   <Target Name="PrepareBuildProperties">
     <ItemGroup>
-      <_BuildProperties Include="RestorePackagesPath=$(MSBuildProjectDirectory)\packages" />
       <_BuildProperties Include="VersionSuffix=$(SemanticTag)" />
       <_BuildProperties Include="PackageOutputPath=$(OutputDirectory)" />
+      <_BuildProperties Include="IncludeSymbols=true" />
     </ItemGroup>
     
     <ItemGroup>

--- a/standard/repository-v2/TeamCity.Task.proj
+++ b/standard/repository-v2/TeamCity.Task.proj
@@ -67,8 +67,9 @@
             <_AllProjects Include="@(NUnitProjects)" />
             <_AllProjects Include="@(OctoPackProjects)" />
             <_AllProjects Include="@(OutputBinaryProjects)" />
+            <_AllProjects Include="SolutionPackages\SolutionPackages.*proj" />
         </ItemGroup>
-        <MSBuild Projects="@(_AllProjects)" Targets="Restore" ToolsVersion="$(PreferredMSBuildToolsVersion)" BuildInParallel="true" Properties="@(_BuildProperties)" />
+        <MSBuild Projects="@(_AllProjects)" Targets="Restore" ToolsVersion="$(PreferredMSBuildToolsVersion)" BuildInParallel="true" Properties="@(_BuildProperties);RestorePackagesPath=$(MSBuildProjectDirectory)\packages" />
     </Target>
 
     <Target Name="BuildAndTest" DependsOnTargets="Build;RunNUnitTests">

--- a/stylecop/StyleCopAnalyzers.props
+++ b/stylecop/StyleCopAnalyzers.props
@@ -13,7 +13,9 @@
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
     <!-- Keep '#warning' and some internally-suppressed warnings as warnings: -->
     <WarningsNotAsErrors>1030,1701,1702</WarningsNotAsErrors>
-    
+    <!-- Do not fail on SemVer 2 compatibility warnings when building packages. -->
+    <NoWarn>$(NoWarn),NU5105</NoWarn>
+
   </PropertyGroup>
 
   <!-- Enable stylecop analyzers for all non-release builds or a release build that's running a build in visual studio (i.e. Intellisense). -->


### PR DESCRIPTION
* Do not fail when building a package using SemVer 2 naming features.
* Always build symbol packages.
* If a SolutionPackages project exists, include it when performing Package Restore.
* Fix a bug where packages which provide targets files might not be imported properly.