### PR TITLE
Set some more NuGet-related defaults

### DIFF
--- a/stylecop/StyleCopAnalyzers.props
+++ b/stylecop/StyleCopAnalyzers.props
@@ -14,9 +14,12 @@
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
     <!-- Keep '#warning' and some internally-suppressed warnings as warnings: -->
     <WarningsNotAsErrors>1030,1701,1702</WarningsNotAsErrors>
+    <!-- Do not fail builds when packages are discovered to be vulnerable. -->
+    <WarningsNotAsErrors>$(WarningsNotAsErrors);NU1901;NU1902;NU1903;NU1904</WarningsNotAsErrors>
     <!-- Do not fail on SemVer 2 compatibility warnings when building packages. -->
     <NoWarn>$(NoWarn),NU5105</NoWarn>
 
+    <GenerateDocumentationFile Condition="'$(GenerateDocumentationFile)' == '' and '$(GeneratePackageOnBuild)' == 'True'">True</GenerateDocumentationFile>
   </PropertyGroup>
 
   <!-- Enable stylecop analyzers for all non-release builds or a release build that's running a build in visual studio (i.e. Intellisense). -->


### PR DESCRIPTION
* Prevent security warnings from failing the build.
* By default, generate documentation for packaged libraries.