### PR TITLE
Fix version numbering broken by SourceLink

### DIFF
--- a/standard/ci-teamcity/StandardVersionedBuildDotNetDebug.xml
+++ b/standard/ci-teamcity/StandardVersionedBuildDotNetDebug.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<meta-runner name="Standard Versioned Build: dotnet">
+<meta-runner name="Standard Versioned Build: dotnet debug">
   <description>Standard build, with semantic and auto-versioning.</description>
   <settings>
     <parameters>
@@ -158,7 +158,7 @@ Put-Parameter 'system.SemanticTag' $semanticTag;]]></param>
           <param name="required.sdk" value="%MSBuildSDKVersions%" />
           <param name="targets" value="BuildAndPackage" />
           <param name="teamcity.step.mode" value="default" />
-          <param name="args" value="/p:SemanticTag=%system.SemanticTag% /p:EnableSourceControlManagerQueries=false" />
+          <param name="args" value="/p:SemanticTag=%system.SemanticTag% /p:EnableSourceControlManagerQueries=false /v:diag" />
         </parameters>
       </runner>
     </build-runners>

--- a/standard/repository-v2/Common.props
+++ b/standard/repository-v2/Common.props
@@ -7,6 +7,13 @@
 
     <UseTeamCityLogging>False</UseTeamCityLogging>
     <UseTeamCityLogging Condition="'$(TEAMCITY_VERSION)' != ''">True</UseTeamCityLogging>
+    
+    <!--
+        SourceLink inspects the repository working copy for version information. Even if SourceLink is
+        disabled, this information is still fetched and injected into the AssemblyInformationalVersion.
+        This breaks our own versioning system.
+      -->
+    <EnableSourceControlManagerQueries>False</EnableSourceControlManagerQueries>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
Disable this at the build runner level as well as the build scripts.

refs EP-47400